### PR TITLE
Add autoSubmit setting for automatic transcription submission

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,9 @@ export default function piTranscribe(pi: ExtensionAPI): void {
       preferredLanguages: previous.preferredLanguages,
       transcriptionLanguage: previous.transcriptionLanguage,
       chineseOutput: previous.chineseOutput,
+      // Carry the flag through this re-configuration path: it runs when the
+      // configured model file went missing and the user picks a new model.
+      autoSubmit: previous.autoSubmit,
       currentModelId: previous.model.id,
       microphone: previous.microphone,
     });
@@ -191,8 +194,24 @@ export default function piTranscribe(pi: ExtensionAPI): void {
         const seconds = pcm.length / CAPTURE_SAMPLE_RATE;
 
         if (text) {
-          ctx.ui.pasteToEditor(text);
-          ctx.ui.notify(`Transcribed ${seconds.toFixed(1)}s of audio`, "info");
+          // Local addition (autoSubmit feature): this is the behavior switch,
+          // the only place the setting changes what happens. True = send the
+          // transcription as a user message immediately (the same code path
+          // as pressing Enter, queued as steer while Pi is busy). False = the
+          // original behavior: paste into the editor and wait for Enter.
+          if (settings?.autoSubmit) {
+            const existing = ctx.ui.getEditorText().replace(/\s+$/, "");
+            const combined = existing ? `${existing} ${text}` : text;
+            await pi.sendUserMessage(combined, { deliverAs: "steer" });
+            ctx.ui.setEditorText("");
+            ctx.ui.notify(
+              `Transcribed ${seconds.toFixed(1)}s of audio — submitted`,
+              "info",
+            );
+          } else {
+            ctx.ui.pasteToEditor(text);
+            ctx.ui.notify(`Transcribed ${seconds.toFixed(1)}s of audio`, "info");
+          }
         } else {
           ctx.ui.notify(`No speech detected in ${seconds.toFixed(1)}s of audio`, "warning");
         }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -87,6 +87,11 @@ type ModelSelectionOptions = {
   preferredLanguages?: readonly string[];
   transcriptionLanguage?: TranscriptionLanguage;
   chineseOutput?: ChineseOutput;
+  // Local addition (autoSubmit feature): this file is pure plumbing. It is the
+  // model-picker flow (first run AND model changes), and it rebuilds settings
+  // via settingsForModel(). The flag must be accepted here and forwarded below,
+  // otherwise choosing a different model would reset it to false.
+  autoSubmit?: boolean;
   currentModelId?: string;
   microphone?: MicrophoneSetting;
   onPreferredLanguagesChange?: (languages: string[]) => Promise<void>;
@@ -199,6 +204,8 @@ export async function runModelSelection(
         preferredLanguages,
         transcriptionLanguage: options.transcriptionLanguage,
         chineseOutput: options.chineseOutput,
+        // The actual forwarding into the freshly built settings object.
+        autoSubmit: options.autoSubmit,
         microphone: options.microphone ?? DEFAULT_MICROPHONE,
       });
       await writeSettings(settings);

--- a/src/settings-menu.ts
+++ b/src/settings-menu.ts
@@ -164,6 +164,15 @@ export async function showSettingsMenu(
       "Microphone",
       microphoneSummary(configured.microphone),
     );
+    // Local addition (autoSubmit feature): this file is the user-facing UI.
+    // It renders the On/Off row below, handles the toggle, and forwards the
+    // flag when a model change rebuilds the settings object. Object.assign()
+    // keeps the in-memory object in sync, so no Pi reload is needed.
+    const autoSubmitChoice = settingChoice(
+      theme,
+      "Auto-submit",
+      configured.autoSubmit ? "On" : "Off",
+    );
     const shortcutChoice = settingChoice(
       theme,
       "Shortcut",
@@ -180,6 +189,7 @@ export async function showSettingsMenu(
       languageChoice,
       ...(showChineseOutput ? [chineseOutputChoice] : []),
       microphoneChoice,
+      autoSubmitChoice,
       shortcutChoice,
       "Done",
     ];
@@ -198,6 +208,9 @@ export async function showSettingsMenu(
         preferredLanguages: configured.preferredLanguages,
         transcriptionLanguage: configured.transcriptionLanguage,
         chineseOutput: configured.chineseOutput,
+        // Preserve the flag when the user changes the model from this menu:
+        // runModelSelection() rebuilds the settings object, see settings.ts.
+        autoSubmit: configured.autoSubmit,
         currentModelId: configured.model.id,
         microphone: configured.microphone,
         onPreferredLanguagesChange: async (preferredLanguages) => {
@@ -247,6 +260,26 @@ export async function showSettingsMenu(
       await writeSettings(updated);
       Object.assign(configured, updated);
       ctx.ui.notify(`Microphone saved as ${microphoneSummary(microphone)}`, "info");
+      continue;
+    }
+    if (choice === autoSubmitChoice) {
+      const selected = await ctx.ui.select(
+        `Auto-submit transcriptions · ${configured.autoSubmit ? "On" : "Off"}`,
+        ["On", "Off"],
+      );
+      if (!selected) continue;
+      const autoSubmit = selected === "On";
+      if (autoSubmit === configured.autoSubmit) continue;
+
+      const updated: TranscribeSettings = { ...configured, autoSubmit };
+      await writeSettings(updated);
+      Object.assign(configured, updated);
+      ctx.ui.notify(
+        autoSubmit
+          ? "Auto-submit enabled: transcriptions are sent immediately"
+          : "Auto-submit disabled: transcriptions are pasted into the editor",
+        "info",
+      );
       continue;
     }
     if (choice === shortcutChoice) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,6 +39,10 @@ export type TranscribeSettings = {
   preferredLanguages: string[];
   transcriptionLanguage: TranscriptionLanguage;
   chineseOutput: ChineseOutput;
+  // Local addition (autoSubmit feature): this type is the single source of
+  // truth for the On/Off state, persisted in pi-transcribe.json. Every other
+  // file only reads or forwards this field.
+  autoSubmit: boolean;
   microphone: MicrophoneSetting;
   model: {
     source: "catalog";
@@ -146,6 +150,10 @@ function validateSettings(value: unknown): TranscribeSettings | undefined {
       preferredLanguages,
     ),
     chineseOutput: validateChineseOutput(value.chineseOutput),
+    // Backward compatibility: config files written before this feature exists
+    // have no autoSubmit key, so a missing/invalid value reads as false
+    // instead of failing validation (which would demand re-configuration).
+    autoSubmit: typeof value.autoSubmit === "boolean" ? value.autoSubmit : false,
     microphone,
     model: {
       source: "catalog",
@@ -198,6 +206,7 @@ type ModelSettingsOptions = {
   preferredLanguages?: readonly string[];
   transcriptionLanguage?: TranscriptionLanguage;
   chineseOutput?: ChineseOutput;
+  autoSubmit?: boolean;
   microphone?: MicrophoneSetting;
 };
 
@@ -222,6 +231,10 @@ export function settingsForModel(
       preferredLanguages,
     ),
     chineseOutput: options.chineseOutput ?? defaultChineseOutput(),
+    // settingsForModel() rebuilds the entire settings object from scratch on
+    // every model selection; without this line the flag would silently reset
+    // to false whenever the user picks a different model.
+    autoSubmit: options.autoSubmit ?? false,
     microphone: { ...(options.microphone ?? DEFAULT_MICROPHONE) },
     model: { source: "catalog", id: modelId, path: modelPath },
   };


### PR DESCRIPTION
## Summary

Dictated text is currently always pasted into the editor, requiring a manual Enter. This adds an **`autoSubmit`** boolean to the `/transcribe` settings menu:

- **On** — the transcription is sent immediately as a user message: text already in the editor is merged in, the editor is cleared, and if the agent is busy the message is queued as steering (the same code path as pressing Enter).
- **Off** (default) — original behavior: paste into the editor only.

## Changes

- `settings.ts` — schema field; missing key in old configs defaults to `false` (backward-compatible); forwarded in `settingsForModel()`
- `settings-menu.ts` — On/Off row in the `/transcribe` menu
- `onboarding.ts` / `index.ts` — flag preserved across every settings-rebuild path (model selection, missing-model reconfiguration) so a model change never resets it
- `index.ts` — behavior switch in `stopAndTranscribe()`

No changes to pi core; uses only the public extension API (`pi.sendUserMessage`, `ctx.ui.getEditorText/setEditorText/select/notify`).

## Testing

- Dictation with `autoSubmit: true` sends immediately (idle and while the agent is streaming)
- Pre-typed editor text is merged, not lost; no stray/leading spaces
- `autoSubmit: false` reproduces original paste-only behavior
- Toggling in the menu applies without reload; survives model changes