### PR TITLE
Add inter-extension dictation events

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ Then run `/transcribe-onboarding` to replay the complete onboarding flow. The co
 
 Press the shortcut while Pi has focus, speak, then press it again. A live level meter appears above the editor while recording. `Esc` cancels. Audio is transcribed locally and inserted at the editor cursor. The shortcut is a Pi terminal binding, not a global OS hotkey.
 
+## Inter-extension events
+
+Extensions in the same Pi process can toggle dictation and observe its state through `pi.events`:
+
+```ts
+pi.events.emit("pi-transcribe:toggle", {});
+pi.events.on("pi-transcribe:state", (event) => {
+  // { state: "starting" | "recording" | "transcribing" | "idle" }
+});
+```
+
+The toggle payload is ignored. Toggles outside an active session are ignored, and toggles during another pi-transcribe operation do not start concurrent work. Event constants and state types are exported from `src/events.ts` and re-exported by `src/index.ts`.
+
 ## File transcription and FFmpeg
 
 The agent can call `transcribe_file` for local audio or video files. Transcription jobs share one loaded model; queued files reuse it, while microphone dictation runs before waiting file jobs after any active job finishes. To bound memory use, at most two file operations are admitted at once, only one FFmpeg decoder runs at a time, and decoded audio is limited to 128 MiB (about 35 minutes). File decoding requires the `ffmpeg` executable; microphone dictation does not. Install FFmpeg with your system package manager:

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -28,6 +28,7 @@ try {
   await run(process.execPath, [
     "--test",
     join(outputDirectory, "test", "async-limiter.test.js"),
+    join(outputDirectory, "test", "events.test.js"),
     join(outputDirectory, "test", "transcription-service.test.js"),
   ]);
 } finally {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,43 @@
+import type {
+  EventBus,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+
+export const PI_TRANSCRIBE_TOGGLE_EVENT = "pi-transcribe:toggle";
+export const PI_TRANSCRIBE_STATE_EVENT = "pi-transcribe:state";
+
+export type PiTranscribeState = "starting" | "recording" | "transcribing" | "idle";
+
+export type PiTranscribeStateEvent = { state: PiTranscribeState };
+
+export function emitPiTranscribeState(
+  events: EventBus,
+  state: PiTranscribeState,
+): void {
+  events.emit(PI_TRANSCRIBE_STATE_EVENT, { state } satisfies PiTranscribeStateEvent);
+}
+
+/** Keep toggle events bound to the context for the live session only. */
+export function createPiTranscribeEventBridge(
+  events: EventBus,
+  toggle: (ctx: ExtensionContext) => void,
+): {
+  sessionStarted(ctx: ExtensionContext): void;
+  shutdown(): void;
+} {
+  let currentContext: ExtensionContext | undefined;
+  const stopListening = events.on(PI_TRANSCRIBE_TOGGLE_EVENT, () => {
+    if (currentContext) toggle(currentContext);
+  });
+
+  return {
+    sessionStarted(ctx): void {
+      currentContext = ctx;
+      emitPiTranscribeState(events, "idle");
+    },
+    shutdown(): void {
+      currentContext = undefined;
+      stopListening();
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+  createPiTranscribeEventBridge,
+  emitPiTranscribeState,
+} from "./events.js";
 import { registerFileTranscriptionTool } from "./file-transcription.js";
 import type { PiTranscribeRuntime } from "./runtime.js";
 import { STATUS_WIDGET_KEY } from "./shortcut-core.js";
@@ -25,6 +32,21 @@ export default function piTranscribe(pi: ExtensionAPI): void {
     return loading;
   }
 
+  async function toggleCapture(ctx: ExtensionContext): Promise<void> {
+    let runtime: PiTranscribeRuntime;
+    try {
+      runtime = await loadRuntime();
+    } catch (error) {
+      emitPiTranscribeState(pi.events, "idle");
+      throw error;
+    }
+    await runtime.toggleCapture(ctx);
+  }
+
+  const eventBridge = createPiTranscribeEventBridge(pi.events, (ctx) => {
+    void toggleCapture(ctx).catch(() => undefined);
+  });
+
   const fileTranscription = registerFileTranscriptionTool(pi, {
     getSettings: async () => (await loadRuntime()).requireConfiguredSettingsForTool(),
     getService: async () => (await loadRuntime()).service,
@@ -44,7 +66,7 @@ export default function piTranscribe(pi: ExtensionAPI): void {
           ]);
         }
         try {
-          await (await loadRuntime()).toggleCapture(ctx);
+          await toggleCapture(ctx);
         } catch (error) {
           if (ctx.hasUI) ctx.ui.setWidget(STATUS_WIDGET_KEY, undefined);
           throw error;
@@ -65,8 +87,13 @@ export default function piTranscribe(pi: ExtensionAPI): void {
     });
   }
 
+  pi.on("session_start", async (_event, ctx) => {
+    eventBridge.sessionStarted(ctx);
+  });
+
   pi.on("session_shutdown", async (_event, ctx) => {
     shuttingDown = true;
+    eventBridge.shutdown();
     await fileTranscription.shutdown().catch(() => undefined);
     const loading = runtimePromise;
     if (!loading) return;
@@ -74,3 +101,10 @@ export default function piTranscribe(pi: ExtensionAPI): void {
     await runtime?.shutdown(ctx).catch(() => undefined);
   });
 }
+
+export {
+  PI_TRANSCRIBE_STATE_EVENT,
+  PI_TRANSCRIBE_TOGGLE_EVENT,
+  type PiTranscribeState,
+  type PiTranscribeStateEvent,
+} from "./events.js";

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7,6 +7,10 @@ import { matchesKey } from "@earendil-works/pi-tui";
 import { existsSync } from "node:fs";
 import { CAPTURE_SAMPLE_RATE } from "./audio-constants.js";
 import type { MicrophoneCapture } from "./audio.js";
+import {
+  emitPiTranscribeState,
+  type PiTranscribeState,
+} from "./events.js";
 import type { TranscribeSettings } from "./settings.js";
 import { displayShortcut } from "./shortcut-core.js";
 import {
@@ -63,6 +67,13 @@ export function createPiTranscribeRuntime(
   let audioModulePromise: Promise<typeof import("./audio.js")> | undefined;
   let visualizerModulePromise: Promise<typeof import("./visualizer.js")> | undefined;
   const transcriptionService = new TranscriptionService();
+  let lifecycleState: PiTranscribeState = "idle";
+
+  function emitState(state: PiTranscribeState): void {
+    if (state === lifecycleState) return;
+    lifecycleState = state;
+    emitPiTranscribeState(pi.events, state);
+  }
 
   function loadAudio(): Promise<typeof import("./audio.js")> {
     return (audioModulePromise ??= import("./audio.js"));
@@ -198,6 +209,7 @@ export function createPiTranscribeRuntime(
     } catch {
       // Discarded either way.
     } finally {
+      emitState("idle");
       active.reservation.cancel();
       clearCancelListener();
       ctx.ui.notify("Recording discarded", "info");
@@ -205,6 +217,7 @@ export function createPiTranscribeRuntime(
   }
 
   async function stopAndTranscribe(ctx: ExtensionContext): Promise<void> {
+    emitState("transcribing");
     const { clearTranscribeWidget, showTranscribeStatus } = await loadVisualizer();
     const active = recording!;
     recording = undefined;
@@ -325,6 +338,7 @@ export function createPiTranscribeRuntime(
 
     listenForCancel(ctx);
     ctx.ui.notify("Microphone recording started", "info");
+    emitState("recording");
   }
 
   async function toggleCaptureTask(ctx: ExtensionContext): Promise<void> {
@@ -333,6 +347,7 @@ export function createPiTranscribeRuntime(
       return;
     }
 
+    emitState("starting");
     // First-press module loading and microphone initialization take a
     // noticeable moment; show feedback until the recording meter takes over.
     // Static text on the shared widget slot: an animated spinner repaints every
@@ -340,11 +355,14 @@ export function createPiTranscribeRuntime(
     const { clearTranscribeWidget, showTranscribeStatus } = await loadVisualizer();
     showTranscribeStatus(ctx, "Starting microphone…");
 
-    const configured = await ensureSettings(ctx);
-    if (configured) await startRecording(ctx, configured);
-    // The meter shares the widget slot and has replaced the spinner when
-    // recording began; clear the spinner only when recording never started.
-    if (!recording) clearTranscribeWidget(ctx);
+    try {
+      const configured = await ensureSettings(ctx);
+      if (configured) await startRecording(ctx, configured);
+    } finally {
+      // The meter shares the widget slot and has replaced the spinner when
+      // recording began; clear the spinner only when recording never started.
+      if (!recording) clearTranscribeWidget(ctx);
+    }
   }
 
   function runExclusive(
@@ -356,7 +374,7 @@ export function createPiTranscribeRuntime(
       return operation;
     }
 
-    const nextOperation = task().finally(() => {
+    const nextOperation = Promise.resolve().then(task).finally(() => {
       if (operation === nextOperation) operation = undefined;
     });
     operation = nextOperation;
@@ -364,7 +382,13 @@ export function createPiTranscribeRuntime(
   }
 
   async function toggleCapture(ctx: ExtensionContext): Promise<void> {
-    await runExclusive(ctx, () => toggleCaptureTask(ctx));
+    await runExclusive(ctx, async () => {
+      try {
+        await toggleCaptureTask(ctx);
+      } finally {
+        if (!recording) emitState("idle");
+      }
+    });
   }
 
   async function showSettings(ctx: ExtensionCommandContext): Promise<void> {
@@ -429,6 +453,7 @@ export function createPiTranscribeRuntime(
       const visualizer = await visualizerModulePromise.catch(() => undefined);
       visualizer?.clearTranscribeWidget(ctx);
     }
+    emitState("idle");
   }
 
   return {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,43 @@
+import type {
+  EventBus,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createPiTranscribeEventBridge,
+  PI_TRANSCRIBE_STATE_EVENT,
+  PI_TRANSCRIBE_TOGGLE_EVENT,
+} from "../src/events.js";
+
+function createTestBus(): EventBus {
+  const handlers = new Map<string, (data: unknown) => void>();
+  return {
+    emit: (channel, data) => handlers.get(channel)?.(data),
+    on(channel, handler) {
+      handlers.set(channel, handler);
+      return () => handlers.delete(channel);
+    },
+  };
+}
+
+test("toggle events are bound to the live session", () => {
+  const bus = createTestBus();
+  const context = {} as ExtensionContext;
+  const toggled: ExtensionContext[] = [];
+  const states: unknown[] = [];
+  bus.on(PI_TRANSCRIBE_STATE_EVENT, (event) => states.push(event));
+  const bridge = createPiTranscribeEventBridge(bus, (ctx) => toggled.push(ctx));
+
+  bus.emit(PI_TRANSCRIBE_TOGGLE_EVENT, {});
+  assert.deepEqual(toggled, []);
+
+  bridge.sessionStarted(context);
+  bus.emit(PI_TRANSCRIBE_TOGGLE_EVENT, {});
+  assert.deepEqual(toggled, [context]);
+  assert.deepEqual(states, [{ state: "idle" }]);
+
+  bridge.shutdown();
+  bus.emit(PI_TRANSCRIBE_TOGGLE_EVENT, {});
+  assert.deepEqual(toggled, [context]);
+});


### PR DESCRIPTION
Closes #6

## Summary

- accept `pi-transcribe:toggle` on Pi's shared event bus and route it through the same capture toggle used by the keyboard shortcut
- emit `pi-transcribe:state` with only `{ state: "starting" | "recording" | "transcribing" | "idle" }`
- bind the event listener to the active session context, clean it up on shutdown, and return to `idle` after cancellation or failure paths
- document the small inter-extension contract and add a focused lifecycle test

The integration is process-local and generic; it does not add an HTTP server or any Stream Deck-specific behavior to pi-transcribe. Existing shortcut behavior remains unchanged.

## Testing

- `npm test`
