### PR TITLE
fix: label startup extension by package name

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./src/index.ts";

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "src",
+    "index.ts",
     "README.md",
     "LICENSE"
   ],
@@ -39,7 +40,7 @@
   },
   "pi": {
     "extensions": [
-      "./src/index.ts"
+      "./index.ts"
     ]
   },
   "peerDependencies": {


### PR DESCRIPTION
The extension currently shows up as `src` in Pi, this change makes it show up as `pi-transcribe`.